### PR TITLE
reverse coordinates to adhere to geojson right hand rule spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,6 @@ module.exports = function circleToPolygon(center, radius, numberOfSegments) {
 
   return {
     type: 'Polygon',
-    coordinates: [coordinates]
+    coordinates: [coordinates.reverse()]
   };
 };


### PR DESCRIPTION
I tried taking circles generated by your code and plotting them here: http://geojsonlint.com/

But I got an error that the coordinates have to adhere to the "right hand rule" 

So I reversed the coordinates generated by your code and then it plotted fine. I didn't dig deep into the GeoJSON spec but presumably the circle coordinates have be in clockwise order. Yours are generated in counter-clockwise order. 