### PR TITLE
Refactor away .reverse()

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,12 +24,12 @@ module.exports = function circleToPolygon(center, radius, numberOfSegments) {
   var n = numberOfSegments ? numberOfSegments : 32;
   var coordinates = [];
   for (var i = 0; i < n; ++i) {
-    coordinates.push(offset(center, radius, (2 * Math.PI * i) / n));
+    coordinates.push(offset(center, radius, (2 * Math.PI * -i) / n));
   }
   coordinates.push(coordinates[0]);
 
   return {
     type: 'Polygon',
-    coordinates: [coordinates.reverse()]
+    coordinates: [coordinates]
   };
 };

--- a/index.js
+++ b/index.js
@@ -22,16 +22,11 @@ function offset(c1, distance, bearing) {
 
 module.exports = function circleToPolygon(center, radius, numberOfSegments) {
   var n = numberOfSegments ? numberOfSegments : 32;
-  var flatCoordinates = [];
   var coordinates = [];
   for (var i = 0; i < n; ++i) {
-    flatCoordinates.push.apply(flatCoordinates, offset(center, radius, 2 * Math.PI * i / n));
+    coordinates.push(offset(center, radius, (2 * Math.PI * i) / n));
   }
-  flatCoordinates.push(flatCoordinates[0], flatCoordinates[1]);
-
-  for (var i = 0, j = 0; j < flatCoordinates.length; j += 2) {
-    coordinates[i++] = flatCoordinates.slice(j, j + 2);
-  }
+  coordinates.push(coordinates[0]);
 
   return {
     type: 'Polygon',


### PR DESCRIPTION
This PR achieves two things:
1. It removes the need for the `.reverse()` by passing bearing as a negative number instead of a positive.
2. It directly push each coordinate to the array `coordinates` instead of first pushing them to `flatCoordinates` and then creating `coordinates` from `flatCoordinates`
