### PR TITLE
Hotfix 10 coordinates with 3 elements cause error

### DIFF
--- a/index.input-validation.specs.js
+++ b/index.input-validation.specs.js
@@ -52,16 +52,21 @@ describe("Input verification", () => {
       );
     });
 
-    it("should only accept an array of length 2 as the circles center", () => {
+    it("should only accept an array of length 2 or 3 as the circles center", () => {
       assert.throws(
-        () => circleToPolygon([150, -91, 34], 100, 32),
+        () => circleToPolygon([150], 100, 32),
         Error,
-        "ERROR! Center has to be an array of length two"
+        "ERROR! Center has to be an array of length two or three"
+      );
+      assert.throws(
+        () => circleToPolygon([150, -91, 34, 29.32], 100, 32),
+        Error,
+        "ERROR! Center has to be an array of length two or three"
       );
       assert.throws(
         () => circleToPolygon({}, 100, 32),
         Error,
-        "ERROR! Center has to be an array of length two"
+        "ERROR! Center has to be an array of length two or three"
       );
     });
   });

--- a/index.js
+++ b/index.js
@@ -25,8 +25,9 @@ function offset(c1, distance, bearing) {
 }
 
 function validateCenter(center) {
-  if (!Array.isArray(center) || center.length !== 2) {
-    throw new Error("ERROR! Center has to be an array of length two");
+  const validCenterLengths = [2, 3]
+  if (!Array.isArray(center) || !validCenterLengths.includes(center.length)) {
+    throw new Error("ERROR! Center has to be an array of length two or three");
   }
   const [lng, lat] = center;
   if (typeof lng !== "number" || typeof lat !== "number") {

--- a/index.output-validation.specs.js
+++ b/index.output-validation.specs.js
@@ -274,6 +274,33 @@ describe("Output verification", () => {
           });
         });
       });
+
+      it("should accept coordinates with 'Altitude' or 'Elevation' attribute", () => {
+        const coordinates = circleToPolygon([0, 0, 34], 13, 12).coordinates[0];
+
+        const expectedCoordinates = [
+          [0, 0.000116],
+          [-0.000058, 0.000101],
+          [-0.000101, 0.000058],
+          [-0.000116, -2.145231e-20],
+          [-0.000101, -0.000058],
+          [-0.000058, -0.000101],
+          [1.430154e-20, -0.000116],
+          [0.000058, -0.000101],
+          [0.000101, -0.000058],
+          [0.000116, 7.150773e-21],
+          [0.000101, 0.000058],
+          [0.000058, 0.000101],
+          [0, 0.000116]
+        ];
+
+        coordinates.forEach((cord, cordIndex) => {
+          cord.forEach((value, valueIndex) => {
+            const expectedValue = expectedCoordinates[cordIndex][valueIndex];
+            expect(value).to.be.closeTo(expectedValue, 0.00001);
+          });
+        });
+      });
     });
 
     describe("Testing non-trivial points", () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circle-to-polygon",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Receives a Coordinate, a Radius and a Number of edges and aproximates a circle by creating a polygon that fills its area",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
As mentioned in PR #10, according to [RFC 7946](https://tools.ietf.org/html/rfc7946#section-3.1.1)

```
A position is an array of numbers.  There MUST be two or more elements.
```
and
```
Implementations SHOULD NOT extend positions beyond three elements.
```

In response to above This PR does the following:
- Make sure that center coordinates with two or three element is accepted.
- Update test to test above.
- Bump the version to `2.0.1`.

The PR DOES NOT
-  change `circleToPolygon`'s it's output even if there is an extra third element.
- change `circleToPolygon` to accept more than three elements.

This closes #10 

@gabzim , @drtyh2o Since the specification does technically allow it, would it be a better solution to change validation test of the center coordinate to accept any array as long as the two first elements are valid lng and lat coordinates?