### PR TITLE
Issue 13 possibility to add more options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .vscode
 node_modules
+.DS_Store

--- a/index.js
+++ b/index.js
@@ -26,11 +26,11 @@ function offset(c1, distance, bearing) {
   return [toDegrees(lon), toDegrees(lat)];
 }
 
-module.exports = function circleToPolygon(center, radius, numberOfSegments) {
-  var n = numberOfSegments ? numberOfSegments : 32;
+module.exports = function circleToPolygon(center, radius, options) {
+  var n = getNumberOfSegments(options);
 
   // validateInput() throws error on invalid input and do nothing on valid input
-  validateInput({ center, radius, numberOfSegments });
+  validateInput({ center, radius, numberOfSegments: n });
 
   var coordinates = [];
   for (var i = 0; i < n; ++i) {
@@ -43,3 +43,13 @@ module.exports = function circleToPolygon(center, radius, numberOfSegments) {
     coordinates: [coordinates]
   };
 };
+
+function getNumberOfSegments(options) {
+  if (typeof options === undefined) {
+    return 32;
+  } else if (typeof options === "object") {
+    var numberOfSegments = options.numberOfSegments;
+    return numberOfSegments === undefined ? 32 : numberOfSegments;
+  }
+  return options;
+}

--- a/index.js
+++ b/index.js
@@ -47,9 +47,13 @@ module.exports = function circleToPolygon(center, radius, options) {
 function getNumberOfSegments(options) {
   if (options === undefined) {
     return 32;
-  } else if (typeof options === "object") {
+  } else if (isObjectNotArray(options)) {
     var numberOfSegments = options.numberOfSegments;
     return numberOfSegments === undefined ? 32 : numberOfSegments;
   }
   return options;
+}
+
+function isObjectNotArray(argument) {
+  return typeof argument === "object" && !Array.isArray(argument)
 }

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function circleToPolygon(center, radius, options) {
 };
 
 function getNumberOfSegments(options) {
-  if (typeof options === undefined) {
+  if (options === undefined) {
     return 32;
   } else if (typeof options === "object") {
     var numberOfSegments = options.numberOfSegments;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 "use strict";
+var { validateInput } = require("./input-validation");
+
 function toRadians(angleInDegrees) {
   return (angleInDegrees * Math.PI) / 180;
 }
@@ -22,64 +24,6 @@ function offset(c1, distance, bearing) {
       Math.cos(dByR) - Math.sin(lat1) * Math.sin(lat)
     );
   return [toDegrees(lon), toDegrees(lat)];
-}
-
-function validateCenter(center) {
-  const validCenterLengths = [2, 3]
-  if (!Array.isArray(center) || !validCenterLengths.includes(center.length)) {
-    throw new Error("ERROR! Center has to be an array of length two or three");
-  }
-  const [lng, lat] = center;
-  if (typeof lng !== "number" || typeof lat !== "number") {
-    throw new Error(
-      `ERROR! Longitude and Latitude has to be numbers but where ${typeof lng} and ${typeof lat}`
-    );
-  }
-  if (lng > 180 || lng < -180) {
-    throw new Error(
-      `ERROR! Longitude has to be between -180 and 180 but was ${lng}`
-    );
-  }
-
-  if (lat > 90 || lat < -90) {
-    throw new Error(
-      `ERROR! Latitude has to be between -90 and 90 but was ${lat}`
-    );
-  }
-}
-
-function validateRadius(radius) {
-  if (typeof radius !== "number") {
-    throw new Error(
-      `ERROR! Radius has to be a positive number but was: ${typeof radius}`
-    );
-  }
-
-  if (radius <= 0) {
-    throw new Error(
-      `ERROR! Radius has to be a positive number but was: ${radius}`
-    );
-  }
-}
-
-function validateNumberOfSegments(numberOfSegments) {
-  if (typeof numberOfSegments !== "number" && numberOfSegments !== undefined) {
-    throw new Error(
-      `ERROR! Number of segments has to be a number but was: ${typeof numberOfSegments}`
-    );
-  }
-
-  if (numberOfSegments < 3) {
-    throw new Error(
-      `ERROR! Number of segments has to be at least 3 but was: ${numberOfSegments}`
-    );
-  }
-}
-
-function validateInput({ center, radius, numberOfSegments }) {
-  validateCenter(center);
-  validateRadius(radius);
-  validateNumberOfSegments(numberOfSegments);
 }
 
 module.exports = function circleToPolygon(center, radius, numberOfSegments) {

--- a/input-validation/index.js
+++ b/input-validation/index.js
@@ -1,0 +1,15 @@
+var validateCenter = require("./validateCenter").validateCenter;
+var validateRadius = require("./validateRadius").validateRadius;
+var validateNumberOfSegments = require("./validateNumberOfSegments")
+  .validateNumberOfSegments;
+
+function validateInput({ center, radius, numberOfSegments }) {
+  validateCenter(center);
+  validateRadius(radius);
+  validateNumberOfSegments(numberOfSegments);
+}
+
+exports.validateCenter = validateCenter;
+exports.validateRadius = validateRadius;
+exports.validateNumberOfSegments = validateNumberOfSegments;
+exports.validateInput = validateInput;

--- a/input-validation/validateCenter.js
+++ b/input-validation/validateCenter.js
@@ -1,9 +1,10 @@
 exports.validateCenter = function validateCenter(center) {
-  const validCenterLengths = [2, 3]
+  var validCenterLengths = [2, 3];
   if (!Array.isArray(center) || !validCenterLengths.includes(center.length)) {
     throw new Error("ERROR! Center has to be an array of length two or three");
   }
-  const [lng, lat] = center;
+
+  var [lng, lat] = center;
   if (typeof lng !== "number" || typeof lat !== "number") {
     throw new Error(
       `ERROR! Longitude and Latitude has to be numbers but where ${typeof lng} and ${typeof lat}`
@@ -20,4 +21,4 @@ exports.validateCenter = function validateCenter(center) {
       `ERROR! Latitude has to be between -90 and 90 but was ${lat}`
     );
   }
-}
+};

--- a/input-validation/validateCenter.js
+++ b/input-validation/validateCenter.js
@@ -1,0 +1,23 @@
+exports.validateCenter = function validateCenter(center) {
+  const validCenterLengths = [2, 3]
+  if (!Array.isArray(center) || !validCenterLengths.includes(center.length)) {
+    throw new Error("ERROR! Center has to be an array of length two or three");
+  }
+  const [lng, lat] = center;
+  if (typeof lng !== "number" || typeof lat !== "number") {
+    throw new Error(
+      `ERROR! Longitude and Latitude has to be numbers but where ${typeof lng} and ${typeof lat}`
+    );
+  }
+  if (lng > 180 || lng < -180) {
+    throw new Error(
+      `ERROR! Longitude has to be between -180 and 180 but was ${lng}`
+    );
+  }
+
+  if (lat > 90 || lat < -90) {
+    throw new Error(
+      `ERROR! Latitude has to be between -90 and 90 but was ${lat}`
+    );
+  }
+}

--- a/input-validation/validateNumberOfSegments.js
+++ b/input-validation/validateNumberOfSegments.js
@@ -1,7 +1,7 @@
 exports.validateNumberOfSegments = function validateNumberOfSegments(
   numberOfSegments
 ) {
-  if (typeof numberOfSegments !== "number" && numberOfSegments !== undefined) {
+  if (typeof numberOfSegments !== "number") {
     throw new Error(
       `ERROR! Number of segments has to be a number but was: ${typeof numberOfSegments}`
     );

--- a/input-validation/validateNumberOfSegments.js
+++ b/input-validation/validateNumberOfSegments.js
@@ -2,8 +2,11 @@ exports.validateNumberOfSegments = function validateNumberOfSegments(
   numberOfSegments
 ) {
   if (typeof numberOfSegments !== "number") {
+    const ARGUMENT_TYPE = Array.isArray(numberOfSegments)
+      ? "array"
+      : typeof numberOfSegments;
     throw new Error(
-      `ERROR! Number of segments has to be a number but was: ${typeof numberOfSegments}`
+      `ERROR! Number of segments has to be a number but was: ${ARGUMENT_TYPE}`
     );
   }
 

--- a/input-validation/validateNumberOfSegments.js
+++ b/input-validation/validateNumberOfSegments.js
@@ -1,0 +1,15 @@
+exports.validateNumberOfSegments = function validateNumberOfSegments(
+  numberOfSegments
+) {
+  if (typeof numberOfSegments !== "number" && numberOfSegments !== undefined) {
+    throw new Error(
+      `ERROR! Number of segments has to be a number but was: ${typeof numberOfSegments}`
+    );
+  }
+
+  if (numberOfSegments < 3) {
+    throw new Error(
+      `ERROR! Number of segments has to be at least 3 but was: ${numberOfSegments}`
+    );
+  }
+};

--- a/input-validation/validateRadius.js
+++ b/input-validation/validateRadius.js
@@ -1,0 +1,13 @@
+exports.validateRadius = function validateRadius(radius) {
+  if (typeof radius !== "number") {
+    throw new Error(
+      `ERROR! Radius has to be a positive number but was: ${typeof radius}`
+    );
+  }
+
+  if (radius <= 0) {
+    throw new Error(
+      `ERROR! Radius has to be a positive number but was: ${radius}`
+    );
+  }
+};

--- a/test/index.input-validation.specs.js
+++ b/test/index.input-validation.specs.js
@@ -161,7 +161,7 @@ describe("Input verification", () => {
       assert.throw(
         () => circleToPolygon([-59.99029, -58.99029], 3, [23]),
         Error,
-        "ERROR! Number of segments has to be a number but was: object"
+        "ERROR! Number of segments has to be a number but was: array"
       );
     });
 

--- a/test/index.input-validation.specs.js
+++ b/test/index.input-validation.specs.js
@@ -149,24 +149,38 @@ describe("Input verification", () => {
       );
     });
 
-    it("should throw error on too low value of numberOfSegments", () => {
-      assert.throws(
-        () => circleToPolygon([-59.99029, -58.99029], 50, 0),
-        Error,
-        "ERROR! Number of segments has to be at least 3 but was: 0"
-      );
+    describe("On too low numberOfSegments value", () => {
+      it("numberOfSegments is < 0", () => {
+        assert.throws(
+          () => circleToPolygon([-59.99029, -58.99029], 50, -10),
+          Error,
+          "ERROR! Number of segments has to be at least 3 but was: -10"
+        );
+      });
 
-      assert.throws(
-        () => circleToPolygon([-59.99029, -58.99029], 50, 1),
-        Error,
-        "ERROR! Number of segments has to be at least 3 but was: 1"
-      );
+      it("numberOfSegments is zero (0)", () => {
+        assert.throws(
+          () => circleToPolygon([-59.99029, -58.99029], 50, 0),
+          Error,
+          "ERROR! Number of segments has to be at least 3 but was: 0"
+        );
+      });
+  
+      it("numberOfSegments is one (1)", () => {
+        assert.throws(
+          () => circleToPolygon([-59.99029, -58.99029], 50, 1),
+          Error,
+          "ERROR! Number of segments has to be at least 3 but was: 1"
+        );
+      });
 
-      assert.throws(
-        () => circleToPolygon([-59.99029, -58.99029], 50, 2),
-        Error,
-        "ERROR! Number of segments has to be at least 3 but was: 2"
-      );
-    });
+      it("numberOfSegments is 2 (2)", () => {
+        assert.throws(
+          () => circleToPolygon([-59.99029, -58.99029], 50, 2),
+          Error,
+          "ERROR! Number of segments has to be at least 3 but was: 2"
+        );
+      });
+    })
   });
 });

--- a/test/index.input-validation.specs.js
+++ b/test/index.input-validation.specs.js
@@ -119,6 +119,14 @@ describe("Input verification", () => {
       );
     });
 
+    it("should throw error if numberOfSegments values is zero", () => {
+      assert.throws(
+        () => circleToPolygon([-59.99029, -58.99029], 50, 0),
+        Error,
+        "ERROR! Number of segments has to be at least 3 but was: 0"
+      );
+    });
+
     it("should NOT throw error when numberOfSegments is undefined", () => {
       assert.doesNotThrow(
         () => circleToPolygon([-59.99029, -58.99029], 50),

--- a/test/index.input-validation.specs.js
+++ b/test/index.input-validation.specs.js
@@ -149,6 +149,14 @@ describe("Input verification", () => {
       );
     });
 
+    it("should throw error when numberOfSegments is a function", () => {
+      assert.throw(
+        () => circleToPolygon([-59.99029, -58.99029], 3, function(){}),
+        Error,
+        "ERROR! Number of segments has to be a number but was: function"
+      );
+    });
+
     describe("On too low numberOfSegments value", () => {
       it("numberOfSegments is < 0", () => {
         assert.throws(

--- a/test/index.input-validation.specs.js
+++ b/test/index.input-validation.specs.js
@@ -157,6 +157,14 @@ describe("Input verification", () => {
       );
     });
 
+    it("should throw error when numberOfSegments is an array", () => {
+      assert.throw(
+        () => circleToPolygon([-59.99029, -58.99029], 3, [23]),
+        Error,
+        "ERROR! Number of segments has to be a number but was: object"
+      );
+    });
+
     describe("On too low numberOfSegments value", () => {
       it("numberOfSegments is < 0", () => {
         assert.throws(

--- a/test/index.input-validation.specs.js
+++ b/test/index.input-validation.specs.js
@@ -1,5 +1,5 @@
 const { assert } = require("chai");
-const circleToPolygon = require(".");
+const circleToPolygon = require("..");
 
 describe("Input verification", () => {
   describe("Validating center input", () => {

--- a/test/index.output-validation.specs.js
+++ b/test/index.output-validation.specs.js
@@ -142,6 +142,23 @@ describe("Output verification", () => {
         });
       });
 
+      it("should give same value when numberOfSegemnts is undefined or 32", () => {
+        const expectedCoordinates = circleToPolygon([131.034184, -25.343467], 5000, 32)
+        .coordinates[0];
+        const coordinates = circleToPolygon(
+          [131.034184, -25.343467],
+          5000,
+          undefined
+        ).coordinates[0];
+
+        coordinates.forEach((cord, cordIndex) => {
+          cord.forEach((value, valueIndex) => {
+            const expectedValue = expectedCoordinates[cordIndex][valueIndex];
+            expect(value).to.be.closeTo(expectedValue, 0.00001);
+          });
+        });
+      });
+
       it("should give correct coordinates for point west of GMT, north of equator", () => {
         const coordinates = circleToPolygon([-121.003331, 66.001764], 50000, 64)
           .coordinates[0];

--- a/test/index.output-validation.specs.js
+++ b/test/index.output-validation.specs.js
@@ -1,5 +1,5 @@
 const { expect } = require("chai");
-const circleToPolygon = require("./index.js");
+const circleToPolygon = require("../index.js");
 
 describe("Output verification", () => {
   describe("Polygon should have correct attributes", () => {

--- a/test/index.output-validation.specs.js
+++ b/test/index.output-validation.specs.js
@@ -159,6 +159,23 @@ describe("Output verification", () => {
         });
       });
 
+      it("should give same value when numberOfSegemnts is { numberOfSegments: undefined } or 32", () => {
+        const expectedCoordinates = circleToPolygon([131.034184, -25.343467], 5000, 32)
+        .coordinates[0];
+        const coordinates = circleToPolygon(
+          [131.034184, -25.343467],
+          5000,
+          { numberOfSegments: undefined }
+        ).coordinates[0];
+
+        coordinates.forEach((cord, cordIndex) => {
+          cord.forEach((value, valueIndex) => {
+            const expectedValue = expectedCoordinates[cordIndex][valueIndex];
+            expect(value).to.be.closeTo(expectedValue, 0.00001);
+          });
+        });
+      });
+
       it("should give correct coordinates for point west of GMT, north of equator", () => {
         const coordinates = circleToPolygon([-121.003331, 66.001764], 50000, 64)
           .coordinates[0];

--- a/test/index.output-validation.specs.js
+++ b/test/index.output-validation.specs.js
@@ -329,4 +329,16 @@ describe("Output verification", () => {
       xit("test 2", () => {});
     });
   });
+
+  describe("Testing Different Options", () => {
+    it("should give same result when passing numberOfSegments as number or as object", () => {
+      const sentAsNumber = circleToPolygon([7.023961, 38.870996], 64, 23)
+        .coordinates[0];
+      const sentAsObject = circleToPolygon([7.023961, 38.870996], 64, {
+        numberOfSegments: 23
+      }).coordinates[0];
+
+      expect(sentAsObject).to.eql(sentAsNumber);
+    });
+  });
 });


### PR DESCRIPTION
This PR makes it possible to pass either an `object` or a `number` to `numberOfSegements`. When passed as an object, the value of the key `numberOfSegments` will be used. Identical polygons will be returned when passing a number or passing an object.

This will close #13 and opens up for the possibility to add more options for the creation of the polygon.

~~**TODO:** Check if error should be thrown when `numberOfSegemnts` is an array, or if it should keep current behavior ( _see this post https://github.com/gabzim/circle-to-polygon/issues/9#issuecomment-583929409_ )~~

~~If error should be thrown, then add that functionallity. If error should not be thrown, add `&& !Array.isArray` to `else if (typeof options === "object")` condition for `getNumberOfSegments()`.~~