### PR TITLE
Fixed missing semicolon which causes IE11 to crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function offset(c1, distance, bearing) {
 }
 
 function validateCenter(center) {
-  const validCenterLengths = [2, 3]
+  const validCenterLengths = [2, 3];
   if (!Array.isArray(center) || !validCenterLengths.includes(center.length)) {
     throw new Error("ERROR! Center has to be an array of length two or three");
   }


### PR DESCRIPTION
I had to fix a missing semicolon, which in my angular project lead to a crash in IE11 which complained about that missing semicolon.