### PR TITLE
Up to version 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circle-to-polygon",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Receives a Coordinate, a Radius and a Number of edges and aproximates a circle by creating a polygon that fills its area",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is a necessary bump to implement a fix regarding IE11 that had some problem with missing semicolon according to this PR #23 