### PR TITLE
Add earthRadius option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ polygon:
   - Third Element: Ignored if present
 - `radius` **[Number][numberdef]** **\*required**, can be any number `>0`
 - `numberOfEdges` **[Number][numberdef]** can be any number `>=3`, defaults to 32 when undefined
+- `earthRadius` **[Number][numberdef]** can be any number `>0`, defaults to 6378137 (equatorial Earth radius) when undefined
 
 ## Disclaimers
 

--- a/input-validation/index.js
+++ b/input-validation/index.js
@@ -1,14 +1,17 @@
 var validateCenter = require("./validateCenter").validateCenter;
 var validateRadius = require("./validateRadius").validateRadius;
 var validateNumberOfEdges = require("./validateNumberOfEdges").validateNumberOfEdges;
+var validateEarthRadius = require("./validateEarthRadius").validateEarthRadius;
 
-function validateInput({ center, radius, numberOfEdges }) {
+function validateInput({ center, radius, numberOfEdges, earthRadius }) {
   validateCenter(center);
   validateRadius(radius);
   validateNumberOfEdges(numberOfEdges);
+  validateEarthRadius(earthRadius);
 }
 
 exports.validateCenter = validateCenter;
 exports.validateRadius = validateRadius;
 exports.validateNumberOfEdges = validateNumberOfEdges;
+exports.validateEarthRadius = validateEarthRadius;
 exports.validateInput = validateInput;

--- a/input-validation/validateEarthRadius.js
+++ b/input-validation/validateEarthRadius.js
@@ -1,0 +1,10 @@
+exports.validateEarthRadius = function validateEarthRadius(earthRadius) {
+  if (typeof earthRadius !== "number") {
+    const ARGUMENT_TYPE = Array.isArray(earthRadius) ? "array" : typeof earthRadius;
+    throw new Error(`ERROR! Earth radius has to be a number but was: ${ARGUMENT_TYPE}`);
+  }
+
+  if (earthRadius <= 0) {
+    throw new Error(`ERROR! Earth radius has to be a positive number but was: ${earthRadius}`);
+  }
+};

--- a/test/index.input-validation.specs.js
+++ b/test/index.input-validation.specs.js
@@ -187,4 +187,50 @@ describe("Input verification", () => {
       });
     });
   });
+
+  describe("Validating earthRadius input", () => {
+    it("should NOT throw error when earthRadius is undefined", () => {
+      assert.doesNotThrow(() => circleToPolygon([-59.99029, -58.99029], 100), Error);
+    });
+
+    it("should NOT throw error when earthRadius is a number", () => {
+      assert.doesNotThrow(() => circleToPolygon([-59.99029, -58.99029], 100, { earthRadius: 6371000 }), Error);
+    });
+
+    it("should throw error when earthRadius is a function", () => {
+      assert.throw(
+        () => circleToPolygon([-59.99029, -58.99029], 100, { earthRadius: function () {} }),
+        Error,
+        "ERROR! Earth radius has to be a number but was: function"
+      );
+    });
+
+    it("should throw error when earthRadius is an array", () => {
+      assert.throw(
+        () => circleToPolygon([-59.99029, -58.99029], 100, { earthRadius: [23] }),
+        Error,
+        "ERROR! Earth radius has to be a number but was: array"
+      );
+    });
+
+    it("should throw error on too smal earthRadius value", () => {
+      assert.throws(
+        () => circleToPolygon([-59.99029, -58.99029], 100, { earthRadius: 0 }),
+        Error,
+        `ERROR! Earth radius has to be a positive number but was: 0`
+      );
+
+      assert.throws(
+        () => circleToPolygon([-59.99029, -58.99029], 100, { earthRadius: -1 }),
+        Error,
+        `ERROR! Earth radius has to be a positive number but was: -1`
+      );
+
+      assert.throws(
+        () => circleToPolygon([-59.99029, -58.99029], 100, { earthRadius: -10 }),
+        Error,
+        `ERROR! Earth radius has to be a positive number but was: -10`
+      );
+    });
+  });
 });

--- a/test/index.output-validation.specs.js
+++ b/test/index.output-validation.specs.js
@@ -73,13 +73,13 @@ describe("Output verification", () => {
           [0, 0.000116],
           [-0.000058, 0.000101],
           [-0.000101, 0.000058],
-          [-0.000116, -2.145231e-20],
+          [-0.000116, 0],
           [-0.000101, -0.000058],
           [-0.000058, -0.000101],
-          [1.430154e-20, -0.000116],
+          [0, -0.000116],
           [0.000058, -0.000101],
           [0.000101, -0.000058],
-          [0.000116, 7.150773e-21],
+          [0.000116, 0],
           [0.000101, 0.000058],
           [0.000058, 0.000101],
           [0, 0.000116]
@@ -303,16 +303,70 @@ describe("Output verification", () => {
           [0, 0.000116],
           [-0.000058, 0.000101],
           [-0.000101, 0.000058],
-          [-0.000116, -2.145231e-20],
+          [-0.000116, 0],
           [-0.000101, -0.000058],
           [-0.000058, -0.000101],
-          [1.430154e-20, -0.000116],
+          [0, -0.000116],
           [0.000058, -0.000101],
           [0.000101, -0.000058],
-          [0.000116, 7.150773e-21],
+          [0.000116, 0],
           [0.000101, 0.000058],
           [0.000058, 0.000101],
           [0, 0.000116]
+        ];
+
+        coordinates.forEach((cord, cordIndex) => {
+          cord.forEach((value, valueIndex) => {
+            const expectedValue = expectedCoordinates[cordIndex][valueIndex];
+            expect(value).to.be.closeTo(expectedValue, 0.00001);
+          });
+        });
+      });
+
+      it("should give correct coordinates for center in [0, 0] and equatorial Earth radius", () => {
+        const coordinates = circleToPolygon([0, 0], 1000000, { numberOfEdges: 12, earthRadius: 6378137 }).coordinates[0];
+
+        const expectedCoordinates = [
+          [ 0, 8.983152 ],
+          [ -4.519349, 7.771613 ],
+          [ -7.795555, 4.477753 ],
+          [ -8.983152, 0 ],
+          [ -7.795555, -4.477753 ],
+          [ -4.519349, -7.771613 ],
+          [ 0, -8.983152 ],
+          [ 4.519349, -7.771613 ],
+          [ 7.795555, -4.477753 ],
+          [ 8.983152, 0 ],
+          [ 7.795555, 4.477753 ],
+          [ 4.519349, 7.771613 ],
+          [ 0, 8.983152 ]
+        ];
+
+        coordinates.forEach((cord, cordIndex) => {
+          cord.forEach((value, valueIndex) => {
+            const expectedValue = expectedCoordinates[cordIndex][valueIndex];
+            expect(value).to.be.closeTo(expectedValue, 0.00001);
+          });
+        });
+      });
+
+      it("should give correct coordinates for center in [0, 0] and mean Earth radius", () => {
+        const coordinates = circleToPolygon([0, 0], 1000000, { numberOfEdges: 12, earthRadius: 6371008.8 }).coordinates[0];
+
+        const expectedCoordinates = [
+          [ 0, 8.993203 ],
+          [ -4.524468, 7.780290 ],
+          [ -7.804312, 4.482732 ],
+          [ -8.993203, 0 ],
+          [ -7.804312, -4.482732 ],
+          [ -4.524468, -7.780290 ],
+          [ 0, -8.993203 ],
+          [ 4.524468, -7.780290 ],
+          [ 7.804312, -4.482732 ],
+          [ 8.993203, 0 ],
+          [ 7.804312, 4.482732 ],
+          [ 4.524468, 7.780290 ],
+          [ 0, 8.993203 ]
         ];
 
         coordinates.forEach((cord, cordIndex) => {


### PR DESCRIPTION
Add earthRadius option, to fix compatibility issues when combining calculations with other libraries. For example, [mapbox-gl-js](https://github.com/mapbox/mapbox-gl-js/blob/main/src/geo/lng_lat.js#L11) uses [mean Earth radius](https://en.wikipedia.org/wiki/Earth_radius#Mean_radius). Some libraries already support to customize Earth radius in a similar way (e.g. [geodesy](https://github.com/chrisveness/geodesy/blob/master/latlon-spherical.js#L187)).