### PR TITLE
[Bugfix] Cannot read property 'numberOfEdges' of null

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = function circleToPolygon(center, radius, options) {
 };
 
 function getNumberOfEdges(options) {
-  if (options === undefined) {
+  if (isUndefinedOrNull(options)) {
     return 32;
   } else if (isObjectNotArray(options)) {
     var numberOfEdges = options.numberOfEdges;
@@ -59,7 +59,7 @@ function getNumberOfEdges(options) {
 }
 
 function getEarthRadius(options) {
-  if (options === undefined) {
+  if (isUndefinedOrNull(options)) {
     return defaultEarthRadius;
   } else if (isObjectNotArray(options)) {
     var earthRadius = options.earthRadius;
@@ -69,7 +69,7 @@ function getEarthRadius(options) {
 }
 
 function getBearing(options) {
-  if (options === undefined) {
+  if (isUndefinedOrNull(options)) {
     return 0;
   } else if (isObjectNotArray(options)) {
     var bearing = options.bearing;
@@ -81,4 +81,7 @@ function getBearing(options) {
 function isObjectNotArray(argument) {
   return argument !== null && typeof argument === "object" && !Array.isArray(argument);
 }
+
+function isUndefinedOrNull(argument) {
+  return argument === null || argument === undefined;
 }

--- a/index.js
+++ b/index.js
@@ -79,5 +79,6 @@ function getBearing(options) {
 }
 
 function isObjectNotArray(argument) {
-  return typeof argument === "object" && !Array.isArray(argument);
+  return argument !== null && typeof argument === "object" && !Array.isArray(argument);
+}
 }

--- a/test/index.output-validation.specs.js
+++ b/test/index.output-validation.specs.js
@@ -169,6 +169,19 @@ describe("Output verification", () => {
         });
       });
 
+      it("should give same value when options is null as when undefined", () => {
+        const expectedCoordinates = circleToPolygon([131.034184, -25.343467], 5000, 32)
+          .coordinates[0];
+        const coordinates = circleToPolygon([131.034184, -25.343467], 5000, null).coordinates[0];
+
+        coordinates.forEach((cord, cordIndex) => {
+          cord.forEach((value, valueIndex) => {
+            const expectedValue = expectedCoordinates[cordIndex][valueIndex];
+            expect(value).to.be.closeTo(expectedValue, 0.00001);
+          });
+        });
+      });
+
       it("should give correct coordinates for point west of GMT, north of equator", () => {
         const coordinates = circleToPolygon([-121.003331, 66.001764], 50000, 64).coordinates[0];
 


### PR DESCRIPTION
## Description

- Passing `null` as the third parameter (options) would throw `TypeError: Cannot read property 'numberOfEdges' of null`
  This was fixed by checking if `options` are `null` or `undefined` instead of only `undefined`
- `isObjectNotArray()` now returns false for `null`