### PR TITLE
Test only with maintained Node versions

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 16.x, 17.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
### Description

Github Actions currently run tests with no longer maintained Node versions while at the same time not testing with the latest versions. This PR fixes this.

**Node versions before:** 10, 12, 14, 15
**Node versions after:** 12, 14, 16, 17

https://nodejs.org/en/about/releases/
